### PR TITLE
Add gpt-4-0125-preview as a model option

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,31 @@ One click deploy with Vercel
 4. Run `yarn` or `npm install`, depending on whether you have yarn or npm installed.
 5. Launch the app by running `yarn dev` or `npm run dev`
 
+### Running it locally using docker compose
+1. Ensure that you have the following installed:
+
+   - [docker](https://www.docker.com/) (v24.0.7 or above)
+      ```bash
+      curl https://get.docker.com | sh \
+      && sudo usermod -aG docker $USER
+      ```
+
+2. Build the docker image
+   ```
+   docker compose build
+   ```
+
+3. Build and start the container using docker compose
+   ```
+   docker compose build
+   docker compose up -d
+   ```
+
+4. Stop the container
+   ```
+   docker compose down
+   ```
+
 # ⭐️ Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=ztjhz/BetterChatGPT&type=Date)](https://github.com/ztjhz/BetterChatGPT/stargazers)

--- a/README.md
+++ b/README.md
@@ -135,8 +135,8 @@ One click deploy with Vercel
 
 1. Ensure that you have the following installed:
 
-   - [node.js](https://nodejs.org/en/)
-   - [yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/)
+   - [node.js](https://nodejs.org/en/) (v14.18.0 or above)
+   - [yarn](https://yarnpkg.com/) or [npm](https://www.npmjs.com/) (6.14.15 or above)
 
 2. Clone this [repository](https://github.com/ztjhz/BetterChatGPT) by running `git clone https://github.com/ztjhz/BetterChatGPT.git`
 3. Navigate into the directory by running `cd BetterChatGPT`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.4'
+
+services:
+  ui_dev:
+    restart: always
+    image: better-chat-gpt
+    build:
+      context: ./
+    ports:
+      - 5173:3000

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -48,7 +48,7 @@ export const modelMaxToken = {
   'gpt-4-32k-0314': 32768,
   'gpt-4-32k-0613': 32768,
   'gpt-4-1106-preview': 128000,
-  'gpt-4-0125-preview': 4096,
+  'gpt-4-0125-preview': 128000,
 };
 
 export const modelCost = {

--- a/src/constants/chat.ts
+++ b/src/constants/chat.ts
@@ -25,6 +25,7 @@ export const modelOptions: ModelOptions[] = [
   'gpt-4',
   'gpt-4-32k',
   'gpt-4-1106-preview',
+  'gpt-4-0125-preview'
   // 'gpt-3.5-turbo-0301',
   // 'gpt-4-0314',
   // 'gpt-4-32k-0314',
@@ -47,6 +48,7 @@ export const modelMaxToken = {
   'gpt-4-32k-0314': 32768,
   'gpt-4-32k-0613': 32768,
   'gpt-4-1106-preview': 128000,
+  'gpt-4-0125-preview': 4096,
 };
 
 export const modelCost = {
@@ -103,6 +105,10 @@ export const modelCost = {
     completion: { price: 0.12, unit: 1000 },
   },
   'gpt-4-1106-preview': {
+    prompt: { price: 0.01, unit: 1000 },
+    completion: { price: 0.03, unit: 1000 },
+  },
+  'gpt-4-0125-preview': {
     prompt: { price: 0.01, unit: 1000 },
     completion: { price: 0.03, unit: 1000 },
   },

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -53,6 +53,7 @@ export type ModelOptions =
   | 'gpt-4'
   | 'gpt-4-32k'
   | 'gpt-4-1106-preview'
+  | 'gpt-4-0125-preview'
   | 'gpt-3.5-turbo'
   | 'gpt-3.5-turbo-16k'
   | 'gpt-3.5-turbo-1106'


### PR DESCRIPTION
This pull request adds the gpt-4-0125-preview as a model option. It also updates the token limit to 128000 as per the documentation provided by OpenAI. Additionally, it fixes a typo in the gpt-4-0125 context length. Lastly, it adds Node/NPM version information to the readme and includes instructions for running the app locally using Docker Compose.